### PR TITLE
UX: Change edit modal primary button label to `Save Edit`

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -19,7 +19,7 @@ en:
       modal:
         title: "Edit Table"
         cancel: "cancel"
-        create: "Update Table"
+        create: "Save Edit"
         reason: "why are you editing?"
         trigger_reason: "Add reason for edit"
       default_edit_reason: "Update Table with Table Editor"


### PR DESCRIPTION
To add consistency with naming used in other areas of the composer, this PR changes the label of the primary button from  <kbd>Update Table</kbd> to <kbd>Save Edit</kbd>