### PR TITLE
FIX: Edit Table button appearing in all `<table>` elements

### DIFF
--- a/javascripts/discourse/api-initializers/table-editor.js
+++ b/javascripts/discourse/api-initializers/table-editor.js
@@ -90,7 +90,7 @@ export default apiInitializer("0.11.1", (api) => {
       }
 
       schedule("afterRender", () => {
-        const tables = post.querySelectorAll("table");
+        const tables = post.querySelectorAll(".md-table table");
         generatePopups(tables, helper.widget.attrs);
       });
     },


### PR DESCRIPTION
When posts include a content as well as a `<table>` element for other purposes such as with the `discourse-calendar` plugin. These tables get decorated with the <kbd>Edit Table</kbd> button like so:

<img width="820" alt="Screen Shot 2022-08-10 at 4 11 43 PM" src="https://user-images.githubusercontent.com/30090424/184038597-f9bfd776-0723-4209-b5ea-d76a89ee4ea0.png">

This **PR resolves this issue** by first querying for selectors with the `.md-table` class.
