### PR TITLE
UX: Default to wide tables

### DIFF
--- a/javascripts/discourse/components/spreadsheet-editor.js
+++ b/javascripts/discourse/components/spreadsheet-editor.js
@@ -102,6 +102,9 @@ export default class SpreadsheetEditor extends Component {
       ["", "", ""],
       ["", "", ""],
       ["", "", ""],
+      ["", "", ""],
+      ["", "", ""],
+      ["", "", ""],
     ];
 
     const columns = [
@@ -120,6 +123,12 @@ export default class SpreadsheetEditor extends Component {
       {
         title: I18n.t(
           themePrefix("discourse_table_builder.default_header.col_3")
+        ),
+        width: this.defaultColWidth,
+      },
+      {
+        title: I18n.t(
+          themePrefix("discourse_table_builder.default_header.col_4")
         ),
         width: this.defaultColWidth,
       },

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -27,5 +27,6 @@ en:
       col_1: "Column 1"
       col_2: "Column 2"
       col_3: "Column 3"
+      col_4: "Column 4"
   theme_metadata:
     description: "Adds a button to the composer to easily build tables in markdown"

--- a/scss/modal/insert-table-modal.scss
+++ b/scss/modal/insert-table-modal.scss
@@ -25,7 +25,7 @@
 
   .modal-inner-container {
     --modal-max-width: 90%;
-    width: max-content;
+    width: 100vw;
   }
 
   .modal-body {
@@ -52,6 +52,17 @@
       li {
         margin-block: 0.25rem;
         color: var(--primary-high);
+      }
+    }
+  }
+
+  .jexcel_container {
+    padding: 0.5em;
+    min-width: 100%;
+    .jexcel_content {
+      min-width: 100%;
+      table.jexcel {
+        min-width: 100%;
       }
     }
   }


### PR DESCRIPTION
With tables with only a few columns (say 3-4), I noticed that manipulating the size of the columns was jumpy and not always intuitive. It feels easier to always default to a large modal window, that way fiddling with column widths is less necessary. 

What do you think @keegangeorge? 