### PR TITLE
FIX: Strip null characters

### DIFF
--- a/javascripts/discourse/components/spreadsheet-editor.js
+++ b/javascripts/discourse/components/spreadsheet-editor.js
@@ -184,6 +184,8 @@ export default class SpreadsheetEditor extends Component {
       editedTable = raw.replace(findTableRegex(), newRaw);
     }
 
+    // replace null characters
+    editedTable = editedTable.replace(/\0/g, "\ufffd");
     return editedTable;
   }
 


### PR DESCRIPTION
When copy/pasting things from Numbers, I ran into an issue where the post would not save at all and a 500 error would be raised: 

```
Discourse::InvalidParameters (string contains null byte)
```

The fix replaces all null character, markdown-it does a similar thing: 

https://github.com/discourse/discourse/blob/main/vendor/assets/javascripts/markdown-it.js#L3638-L3640 

Would be nice to add a test for this part of the component in a followup PR (basically checking that original raw gets replaced by jexcel's raw). 