### PR TITLE
DEV: Update `site` and `siteSettings` references

### DIFF
--- a/javascripts/discourse/api-initializers/table-editor.js
+++ b/javascripts/discourse/api-initializers/table-editor.js
@@ -10,9 +10,10 @@ import Session from "discourse/models/session";
 import loadScript from "discourse/lib/load-script";
 import PrettyText, { buildOptions } from "pretty-text/pretty-text";
 import { tokenRange } from "../discourse-table-builder/lib/utilities";
+
 export default apiInitializer("0.11.1", (api) => {
-  const site = api.container.lookup("site:main"),
-    siteSettings = api.container.lookup("site-settings:main");
+  const site = api.container.lookup("service:site");
+  const siteSettings = api.container.lookup("service:site-settings");
 
   function createButton() {
     const openPopupBtn = document.createElement("button");


### PR DESCRIPTION
This PR applies compatibility updates to get rid of the following warnings:
```bash
deprecated.js:35 [THEME 2 'Table Builder'] Deprecation notice: "site:main" is deprecated, use "service:site" instead (deprecated since Discourse 2.9.0.beta7) (removal in Discourse 3.0.0)
e.default @ deprecated.js:35
deprecated.js:35 [THEME 2 'Table Builder'] Deprecation notice: "site-settings:main" is deprecated, use "service:site-settings" instead (deprecated since Discourse 2.9.0.beta7) (removal in Discourse 3.0.0)
```