### PR TITLE
FEATURE: Add unique filename for table exports

### DIFF
--- a/javascripts/discourse/components/spreadsheet-editor.js
+++ b/javascripts/discourse/components/spreadsheet-editor.js
@@ -173,12 +173,18 @@ export default class SpreadsheetEditor extends Component {
   }
 
   buildSpreadsheet(data, columns, opts = {}) {
+    const postNumber = this.args.model?.post_number;
+    const exportFileName = postNumber
+      ? `post-${postNumber}-table-export`
+      : `post-table-export`;
+
     // eslint-disable-next-line no-undef
     this.spreadsheet = jspreadsheet(this.spreadsheet, {
       data,
       columns,
       defaultColAlign: "left",
       wordWrap: true,
+      csvFileName: exportFileName,
       ...opts,
     });
   }


### PR DESCRIPTION
This PR adds a unique filename when exporting a table using the <kbd>Save As</kbd> button in the spreadsheet's context menu.

- If exporting a table for a new post, the filename will be `post-table-export.csv`
- If editing a table for an existing post and exporting, the filename will include the post number in the filename `post-${postNumber}-table-export`  i.e. `post-5-table-export.csv`