### PR TITLE
UX: Improve table modal max width for larger screens

### DIFF
--- a/scss/modal/insert-table-modal.scss
+++ b/scss/modal/insert-table-modal.scss
@@ -26,6 +26,11 @@
   .modal-inner-container {
     --modal-max-width: $reply-area-max-width;
     width: $reply-area-max-width;
+
+    @media screen and (max-width: 1200px) {
+      --modal-max-width: 90%;
+      width: 100vw;
+    }
   }
 
   .modal-body {

--- a/scss/modal/insert-table-modal.scss
+++ b/scss/modal/insert-table-modal.scss
@@ -24,8 +24,8 @@
   align-items: flex-start;
 
   .modal-inner-container {
-    --modal-max-width: 90%;
-    width: 100vw;
+    --modal-max-width: $reply-area-max-width;
+    width: $reply-area-max-width;
   }
 
   .modal-body {


### PR DESCRIPTION
As per [feedback](https://meta.discourse.org/t/table-builder/236016/6?u=keegan), this PR improves the sizing of the table builder's max modal width.

It prevents the modal on very large screens from spanning the full width. While still maintaining a large width based on feedback discovered from [previous PR](https://github.com/discourse/discourse-table-builder/pull/16).

**Before**:
![Screen Shot 2022-08-15 at 1 20 14 PM](https://user-images.githubusercontent.com/30090424/184712813-aafa111a-a6c5-4a63-a91f-fde8dafc13e1.png)
(XL Desktop Full Screen)

**After**:
![Screen Shot 2022-08-15 at 1 20 29 PM](https://user-images.githubusercontent.com/30090424/184712872-46361370-b355-4384-b607-f01de09d8844.png)
(XL Desktop Full Screen)

![Screen Shot 2022-08-15 at 1 26 20 PM](https://user-images.githubusercontent.com/30090424/184712881-78c9f6db-8eba-4acc-80dd-8785364048dc.png)
(Small Desktop Full Screen)
