### PR TITLE
FIX: Ensure helper or post exist before decorations

### DIFF
--- a/javascripts/discourse/api-initializers/table-editor.js
+++ b/javascripts/discourse/api-initializers/table-editor.js
@@ -73,6 +73,9 @@ export default apiInitializer("0.11.1", (api) => {
 
   api.decorateCookedElement(
     (post, helper) => {
+      if (!helper || !post) {
+        return;
+      }
       const canEdit = helper.widget.attrs.canEdit;
 
       if (!canEdit) {


### PR DESCRIPTION
This PR adds compatibility with [Category sidebars](https://github.com/discourse/discourse-category-sidebars). Since the category sidebar component adds a decorated post widget in the topic list view, the table builder must ensure a helper and post exist before attempting to make decorations.

Thus, this PR adds a check for if either the widget helper or post are present before attempting to decorate the post.