### PR TITLE
Revert "DEV: Ensure helper or post exist before decorations (#27)"

### DIFF
--- a/javascripts/discourse/api-initializers/table-editor.js
+++ b/javascripts/discourse/api-initializers/table-editor.js
@@ -73,9 +73,6 @@ export default apiInitializer("0.11.1", (api) => {
 
   api.decorateCookedElement(
     (post, helper) => {
-      if (!helper || !post) {
-        return;
-      }
       const canEdit = helper.widget.attrs.canEdit;
 
       if (!canEdit) {


### PR DESCRIPTION
This reverts commit 2896c69a727f18414afe2d4799cde5efbb0c1293.

The change is not necessary as the problem was actually the result of the category sidebars component. The fix for that is found in this PR → https://github.com/discourse/discourse-category-sidebars/pull/6