### PR TITLE
FIX: Make edit table button text not selectable

### DIFF
--- a/javascripts/discourse/api-initializers/table-editor.js
+++ b/javascripts/discourse/api-initializers/table-editor.js
@@ -18,7 +18,8 @@ export default apiInitializer("0.11.1", (api) => {
       "open-popup-link",
       "btn-default",
       "btn",
-      "btn-icon-text"
+      "btn-icon-text",
+      "btn-edit-table"
     );
     const editIcon = create(
       iconNode("pencil-alt", { class: "edit-table-icon" })

--- a/scss/post/table-edit-decorator.scss
+++ b/scss/post/table-edit-decorator.scss
@@ -2,3 +2,11 @@
   display: inline;
   margin-inline: 0.25em;
 }
+
+.btn-edit-table {
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}


### PR DESCRIPTION
This PR makes the text of the edit table button not selectable so that when post's contents are copied, the edit table label does not copy over as well.

<img width="497" alt="Screen Shot 2022-10-12 at 9 33 28 AM" src="https://user-images.githubusercontent.com/30090424/195398930-654488e3-fa21-4ba4-baf9-578d7578dc56.png">
