### PR TITLE
UX: Reduce confusion when editing tables

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -19,7 +19,7 @@ en:
       modal:
         title: "Edit Table"
         cancel: "cancel"
-        create: "Save Edit"
+        create: "Save"
         reason: "why are you editing?"
         trigger_reason: "Add reason for edit"
       default_edit_reason: "Update Table with Table Editor"


### PR DESCRIPTION
When opening the **Edit Table** modal the primary action button has the label <kbd>✏️ Save Edit</kbd>. This label is causing confusion for some, thinking that the button serves two actions (edit or save) rather than meaning to "Save the edit".

As a result, this PR changes the button's label simply to <kbd>✏️ Save</kbd> to avoid confusion.