### PR TITLE
FIX: do not edit wrong table when post has uploads

### DIFF
--- a/javascripts/discourse-table-builder/lib/utilities.js
+++ b/javascripts/discourse-table-builder/lib/utilities.js
@@ -46,10 +46,10 @@ export function arrayToTable(array, columns) {
 
 /**
  *
- * @returns a regular experssion finding all markdown tables
+ * @returns a regular expression finding all markdown tables
  */
 export function findTableRegex() {
-  return /((\r?){2}|^)([^\r\n]*\|[^\r\n]*(\r?\n)?)+(?=(\r?\n){2}|$)/gm;
+  return /((\r?){2}|^)(^\|[^\r\n]*(\r?\n)?)+(?=(\r?\n){2}|$)/gm;
 }
 
 export function tokenRange(tokens, start, end) {

--- a/javascripts/discourse/components/spreadsheet-editor.js
+++ b/javascripts/discourse/components/spreadsheet-editor.js
@@ -197,10 +197,10 @@ export default class SpreadsheetEditor extends Component {
     const tableToEdit = raw.match(findTableRegex());
     let editedTable;
 
-    if (tableToEdit.length > 1) {
+    if (tableToEdit.length) {
       editedTable = raw.replace(tableToEdit[tableId], newRaw);
     } else {
-      editedTable = raw.replace(tableToEdit[0], newRaw);
+      return raw;
     }
 
     // replace null characters

--- a/test/unit/lib/utilities-test.js
+++ b/test/unit/lib/utilities-test.js
@@ -2,7 +2,10 @@ import { discourseModule } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import mdTableFixture from "../../fixtures/md-table-fixture";
 import mdTableSpecialCharsFixture from "../../fixtures/md-table-special-chars-fixture";
-import { arrayToTable } from "../../../discourse-table-builder/lib/utilities";
+import {
+  arrayToTable,
+  findTableRegex,
+} from "../../../discourse-table-builder/lib/utilities";
 
 discourseModule("Unit | Utilities", function () {
   test("arrayToTable", function (assert) {
@@ -52,6 +55,59 @@ discourseModule("Unit | Utilities", function () {
       arrayToTable(specialCharsTableData),
       mdTableSpecialCharsFixture,
       "it creates a markdown table with special characters in correct alignment"
+    );
+  });
+
+  test("findTableRegex", function (assert) {
+    const oneTable = `|Make|Model|Year|\r\n|--- | --- | ---|\r\n|Toyota|Supra|1998|`;
+
+    assert.strictEqual(
+      oneTable.match(findTableRegex()).length,
+      1,
+      "finds one table in markdown"
+    );
+
+    const threeTables = `## Heading
+|Table1 | PP Port | Device | DP | Medium|
+|--- | --- | --- | --- | ---|
+| Something | (1+2) | Dude | Mate | Bro |
+
+|Table2 | PP Port | Device | DP | Medium|
+|--- | --- | --- | --- | ---|
+| Something | (1+2) | Dude | Mate | Bro |
+| ✅  | (1+2) | Dude | Mate | Bro |
+| ✅  | (1+2) | Dude | Mate | Bro |
+
+|Table3 | PP Port | Device | DP |
+|--- | --- | --- | --- |
+| Something | (1+2) | Dude | Sound |
+|  | (1+2) | Dude | OW |
+|  | (1+2) | Dude | OI |
+
+Random extras
+    `;
+
+    assert.strictEqual(
+      threeTables.match(findTableRegex()).length,
+      3,
+      "finds three tables in markdown"
+    );
+
+    const ignoreUploads = `
+:information_source: Something
+
+[details=Example of a cross-connect in Equinix]
+![image|603x500, 100%](upload://fURYa9mt00rXZITdYhhyeHFJE8J.png)
+[/details]
+
+|Table1 | PP Port | Device | DP | Medium|
+|--- | --- | --- | --- | ---|
+| Something | (1+2) | Dude | Mate | Bro |
+`;
+    assert.strictEqual(
+      ignoreUploads.match(findTableRegex()).length,
+      1,
+      "finds on table, ignoring upload markup"
     );
   });
 });


### PR DESCRIPTION
Previously, the regex was catching uploads as well as tables.

This change ensures only strict tables are matched by requiring that matches start with the pipe character.

Also adds a unit test for `findTableRegex` to describe the expected behaviour of the helper.