### PR TITLE
DEV: Map Discourse locales to vendor spreadsheet locales

### DIFF
--- a/javascripts/discourse-table-builder/lib/context-menu.js
+++ b/javascripts/discourse-table-builder/lib/context-menu.js
@@ -1,0 +1,45 @@
+import I18n from "I18n";
+
+function prefixedLocale(localeString) {
+  return I18n.t(
+    themePrefix(`discourse_table_builder.spreadsheet.${localeString}`)
+  );
+}
+
+export const localeMapping = {
+  noRecordsFound: prefixedLocale("no_records_found"),
+  showingPage: prefixedLocale("showing_page"),
+  show: prefixedLocale("show"),
+  entries: prefixedLocale("entries"),
+  insertANewColumnBefore: prefixedLocale("context_menu.col.before"),
+  insertANewColumnAfter: prefixedLocale("context_menu.col.after"),
+  deleteSelectedColumns: prefixedLocale("context_menu.col.delete"),
+  renameThisColumn: prefixedLocale("context_menu.col.rename"),
+  orderAscending: prefixedLocale("context_menu.order.ascending"),
+  orderDescending: prefixedLocale("context_menu.order.descending"),
+  insertANewRowBefore: prefixedLocale("context_menu.row.before"),
+  insertANewRowAfter: prefixedLocale("context_menu.row.after"),
+  deleteSelectedRows: prefixedLocale("context_menu.row.delete"),
+  copy: prefixedLocale("context_menu.copy"),
+  paste: prefixedLocale("context_menu.paste"),
+  saveAs: prefixedLocale("context_menu.save"),
+  about: prefixedLocale("about"),
+  areYouSureToDeleteTheSelectedRows: prefixedLocale(
+    "prompts.delete_selected_rows"
+  ),
+  areYouSureToDeleteTheSelectedColumns: prefixedLocale(
+    "prompts.delete_selected_cols"
+  ),
+  thisActionWillDestroyAnyExistingMergedCellsAreYouSure: prefixedLocale(
+    "prompts.will_destroy_merged_cells"
+  ),
+  thisActionWillClearYourSearchResultsAreYouSure: prefixedLocale(
+    "prompts.will_clear_search_results"
+  ),
+  thereIsAConflictWithAnotherMergedCell: prefixedLocale(
+    "prompts.conflict_with_merged_cells"
+  ),
+  invalidMergeProperties: prefixedLocale("invalid_merge_props"),
+  cellAlreadyMerged: prefixedLocale("cells_already_merged"),
+  noCellsSelected: prefixedLocale("no_cells_selected"),
+};

--- a/javascripts/discourse/components/spreadsheet-editor.js
+++ b/javascripts/discourse/components/spreadsheet-editor.js
@@ -11,7 +11,7 @@ import { popupAjaxError } from "discourse/lib/ajax-error";
 import I18n from "I18n";
 import { schedule } from "@ember/runloop";
 import { tracked } from "@glimmer/tracking";
-
+import { localeMapping } from "../discourse-table-builder/lib/context-menu";
 export default class SpreadsheetEditor extends Component {
   @tracked showEditReason = false;
   @tracked loading = null;
@@ -189,6 +189,7 @@ export default class SpreadsheetEditor extends Component {
       defaultColAlign: "left",
       wordWrap: true,
       csvFileName: exportFileName,
+      text: localeMapping,
       ...opts,
     });
   }

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -28,5 +28,37 @@ en:
       col_2: "Column 2"
       col_3: "Column 3"
       col_4: "Column 4"
+    spreadsheet:
+      no_records_found: "No records found"
+      showing_page: "Showing page {0} of {1} entries"
+      show: "Show"
+      entries: "entries"
+      about: "About"
+      prompts:
+        delete_selected_rows: "Are you sure to delete the selected rows?"
+        delete_selected_cols: "Are you sure to delete the selected columns?"
+        will_destroy_merged_cells: "This action will destroy any existing merged cells. Are you sure?"
+        will_clear_search_results: "This action will destroy any existing merged cells. Are you sure?"
+        conflicts_with_merged_cells: "There is a conflict with another merged cell"
+      invalid_merge_props: "Invalid merged properties"
+      cells_already_merged: "Cell already merged"
+      no_cells_selected: "No cells selected"
+      context_menu:
+        row:
+          before: "Insert a new row before"
+          after: "Insert a new row after"
+          delete: "Delete selected rows"
+        col:
+          before: "Insert a new column before"
+          after: "Insert a new column after"
+          delete: "Delete selected columns"
+          rename: "Rename this column"
+        order:
+          ascending: "Order ascending"
+          descending: "Order descending"
+        copy: "Copy..."
+        paste: "Paste..."
+        save: "Save as..."
+
   theme_metadata:
     description: "Adds a button to the composer to easily build tables in markdown"


### PR DESCRIPTION
This PR adds additional localizations for text that appears within the spreadsheet (such as context menus). It maps the vendor declared localizations (`jspreadsheet.js`) to custom locales in `/locales/` folder so that text declared through the vendor library can be easily translatable by adding the localized text in locale files.