### PR TITLE
FIX: Screen shaking on mobile view navigation

### DIFF
--- a/scss/post/table-edit-decorator.scss
+++ b/scss/post/table-edit-decorator.scss
@@ -18,23 +18,21 @@
 .mobile-view {
   .btn-edit-table {
     display: none;
+    z-index: 2;
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
   }
 
   .fullscreen-table-wrapper {
     position: relative;
-    border: 1px solid transparent;
 
     &:hover {
-      border: 1px solid var(--primary-low);
       table {
         opacity: 0.5;
       }
       .btn-edit-table {
-        z-index: 2;
         display: block;
-        position: absolute;
-        top: 1rem;
-        left: 1rem;
       }
     }
   }


### PR DESCRIPTION
Setting a border on the `fullscreen-table-wrapper` element causes a small shake in mobile views, especially on topics with multiple tables.

This PR removes the border on the table entirely. This was an almost invisible visual effect when selecting the table (small border width, whole table is set to 50% opacity).

It also makes a small refactor, moving the styles of the button outside of the hover state.