### PR TITLE
FIX: Remove line breaks from cell data

### DIFF
--- a/javascripts/discourse-table-builder/lib/utilities.js
+++ b/javascripts/discourse-table-builder/lib/utilities.js
@@ -33,13 +33,14 @@ export function arrayToTable(array, cols, colPrefix = "col") {
     table +=
       cols
         .map(function (_key, index) {
-          return String(item[`${colPrefix}${index}`] || "");
+          return String(item[`${colPrefix}${index}`] || "").replace(
+            /\r?\n|\r/g,
+            " "
+          );
         })
         .join(" | ") + "|\r\n";
   });
 
-  // Return table
-  console.log(table);
   return table;
 }
 

--- a/test/unit/lib/utilities-test.js
+++ b/test/unit/lib/utilities-test.js
@@ -91,6 +91,25 @@ discourseModule("Unit | Utilities", function () {
     );
   });
 
+  test("arrayToTable returns valid table with multiline cell data", function (assert) {
+    const tableData = [
+      {
+        col0: "Jane\nDoe",
+        col1: "Teri",
+      },
+      {
+        col0: "Finch",
+        col1: "Sami",
+      },
+    ];
+
+    assert.strictEqual(
+      arrayToTable(tableData, ["Col 1", "Col 2"]),
+      `|Col 1 | Col 2|\r\n|--- | ---|\r\n|Jane Doe | Teri|\r\n|Finch | Sami|\r\n`,
+      "it creates a valid table"
+    );
+  });
+
   test("findTableRegex", function (assert) {
     const oneTable = `|Make|Model|Year|\r\n|--- | --- | ---|\r\n|Toyota|Supra|1998|`;
 


### PR DESCRIPTION
Pasting text with line breaks into the table UI results in incorrectly generated table markdown.

This fix strips line breaks from text during table markdown generation.

## Before

https://user-images.githubusercontent.com/849886/221232073-f74eb460-9515-428e-8918-6d664d1ba420.mov

## After

https://user-images.githubusercontent.com/849886/221232274-687aca8e-f6a1-49e6-9def-b41e6f535f96.mov

## Alternative solutions
 - Replace line breaks with `<br>` during table creation and `<b>` with line breaks when instantiating Jspreadsheet  with table data
 -  Setting Jspreadsheet `wordWrap`  option to `false` auto replaces line breaks on paste
