### PR TITLE
UX: Make table builder edit button icon-only

### DIFF
--- a/javascripts/discourse/api-initializers/table-editor.js
+++ b/javascripts/discourse/api-initializers/table-editor.js
@@ -16,7 +16,7 @@ export default apiInitializer("0.11.1", (api) => {
       "open-popup-link",
       "btn-default",
       "btn",
-      "btn-icon-text",
+      "btn-icon",
       "btn-edit-table",
       "no-text"
     );

--- a/javascripts/discourse/api-initializers/table-editor.js
+++ b/javascripts/discourse/api-initializers/table-editor.js
@@ -17,15 +17,16 @@ export default apiInitializer("0.11.1", (api) => {
       "btn-default",
       "btn",
       "btn-icon-text",
-      "btn-edit-table"
+      "btn-edit-table",
+      "no-text"
     );
     const editIcon = create(
       iconNode("pencil-alt", { class: "edit-table-icon" })
     );
-    const openPopupText = document.createTextNode(
-      I18n.t(themePrefix("discourse_table_builder.edit.btn_edit"))
+    openPopupBtn.title = I18n.t(
+      themePrefix("discourse_table_builder.edit.btn_edit")
     );
-    openPopupBtn.append(editIcon, openPopupText);
+    openPopupBtn.append(editIcon);
     return openPopupBtn;
   }
 


### PR DESCRIPTION
Along with the core change: https://github.com/discourse/discourse/pull/20820 to make the expand button icon-only, this PR also makes the table builder's edit button icon-only to maximize space. The label is now moved to the title attribute so it appears in the default HTML tooltip.

<img width="288" alt="Screenshot 2023-03-24 at 12 36 08" src="https://user-images.githubusercontent.com/30090424/227623153-ae9c2b51-f1a0-4d7e-b158-f32c07647979.png">
