### PR TITLE
DEV: Introduce backwards-compat shims for older Discourse core

### DIFF
--- a/javascripts/discourse/pre-initializers/add-module-shims.js
+++ b/javascripts/discourse/pre-initializers/add-module-shims.js
@@ -5,6 +5,7 @@ const themeId = themePrefix("foo").match(/theme_translations\.(\d+)\.foo/)[1];
 const base = `discourse/theme-${themeId}`;
 
 if (!require.entries[`${base}/discourse/components/spreadsheet-editor`]) {
+  // eslint-disable-next-line no-console
   console.warn(
     "Running on an old version of core. discourse-table-builder is shimming modules to keep old imports working."
   );

--- a/javascripts/discourse/pre-initializers/add-module-shims.js
+++ b/javascripts/discourse/pre-initializers/add-module-shims.js
@@ -1,0 +1,34 @@
+// Backwards compatility for core versions before 82b16f4f
+// Can be removed once 3.2.0.beta1 is released, and the compat file is updated
+
+const themeId = themePrefix("foo").match(/theme_translations\.(\d+)\.foo/)[1];
+const base = `discourse/theme-${themeId}`;
+
+if (!require.entries[`${base}/discourse/components/spreadsheet-editor`]) {
+  console.warn(
+    "Running on an old version of core. discourse-table-builder is shimming modules to keep old imports working."
+  );
+
+  define(
+    `discourse/discourse-table-builder/lib/utilities`,
+    ["exports", `${base}/discourse-table-builder/lib/utilities`],
+    function (_exports, utilities) {
+      _exports.tokenRange = utilities.tokenRange;
+      _exports.arrayToTable = utilities.arrayToTable;
+      _exports.findTableRegex = utilities.findTableRegex;
+    }
+  );
+
+  define(
+    `discourse/discourse-table-builder/lib/locale-mapping`,
+    ["exports", `${base}/discourse-table-builder/lib/locale-mapping`],
+    function (_exports, localeMapping) {
+      _exports.localeMapping = localeMapping.localeMapping;
+    }
+  );
+}
+
+export default {
+  name: "add-template-module-shims",
+  initialize() {},
+};


### PR DESCRIPTION
The changes in 8599bfcaff34993ab9e5e7d90edaabb1471a99b6 needed to be applied precisely in-step with the core changes from https://github.com/discourse/discourse/pull/23148. This is impossible to guarantee with a theme - `.discourse-compatibility` does not give us enough precision. So instead, we need some temporary backwards-compatibility shims so that the new relative-import paths still work on old discourse.