### PR TITLE
DEV: Remove unused pagination locale

### DIFF
--- a/javascripts/discourse-table-builder/lib/locale-mapping.js
+++ b/javascripts/discourse-table-builder/lib/locale-mapping.js
@@ -8,7 +8,6 @@ function prefixedLocale(localeString) {
 
 export const localeMapping = {
   noRecordsFound: prefixedLocale("no_records_found"),
-  showingPage: prefixedLocale("showing_page"),
   show: prefixedLocale("show"),
   entries: prefixedLocale("entries"),
   insertANewColumnBefore: prefixedLocale("context_menu.col.before"),

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -30,7 +30,6 @@ en:
       col_4: "Column 4"
     spreadsheet:
       no_records_found: "No records found"
-      showing_page: "Showing page {0} of {1} entries"
       show: "Show"
       entries: "entries"
       about: "About"


### PR DESCRIPTION
This PR removes a locale the locale `showingPage` taken from the jSpreadsheet library. In our usage of table builder, we are not using pagination and this locale is not needed.