### PR TITLE
UX: Confirm before closing unsaved changes

### DIFF
--- a/javascripts/discourse/components/spreadsheet-editor.hbs
+++ b/javascripts/discourse/components/spreadsheet-editor.hbs
@@ -1,6 +1,6 @@
 <DModal
   @title={{i18n this.modalAttributes.title}}
-  @closeModal={{@closeModal}}
+  @closeModal={{this.interceptCloseModal}}
   class="insert-table-modal"
 >
   <:body>
@@ -24,7 +24,7 @@
       <DButton
         @class="btn-flat"
         @label={{theme-prefix "discourse_table_builder.edit.modal.cancel"}}
-        @action={{@closeModal}}
+        @action={{this.interceptCloseModal}}
       />
     </div>
 

--- a/javascripts/discourse/components/spreadsheet-editor.js
+++ b/javascripts/discourse/components/spreadsheet-editor.js
@@ -71,9 +71,7 @@ export default class SpreadsheetEditor extends Component {
         message: I18n.t(
           themePrefix("discourse_table_builder.modal.confirm_close")
         ),
-        didConfirm: () => {
-          this.args.closeModal();
-        },
+        didConfirm: () => this.args.closeModal(),
       });
     } else {
       this.args.closeModal();

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -14,6 +14,7 @@ en:
         new_row: "at the end of a row to insert a new row."
         new_col: "at the end of a column to insert a new  column."
         options: "Right-click on cells to access more options in a dropdown menu."
+      confirm_close: "Are you sure you want to close the table builder? Any unsaved changes will be lost."
     edit:
       btn_edit: "Edit Table"
       modal:


### PR DESCRIPTION
This PR adds a confirmation dialog box when attempting to close the table builder/editor when there are unsaved changes.

This will help prevent accidental closes by pressing <kbd>Esc</kbd> on the keyboard, or accidentally clicking the Cancel or ✖️ button.

When no changes have been made, cancelling or escaping will close without showing a dialog box.

https://github.com/discourse/discourse-table-builder/assets/30090424/24044c13-da8c-4f62-a79a-1689ea6b8c61

